### PR TITLE
docs(managed-street): document direction default 'none' and opt-in co…

### DIFF
--- a/docs/managed-street/component-street-segment.md
+++ b/docs/managed-street/component-street-segment.md
@@ -20,7 +20,7 @@ A custom sidebar in 3DStreet Editor allows users to edit a subset of `street-seg
 | width      | number | -        | Width of the segment in meters |
 | length     | number | -        | Length of the segment in meters |
 | level      | int    | 0        | Vertical level of the segment (-1 to 2) |
-| direction  | string | -        | Direction of traffic flow: 'none', 'inbound', or 'outbound' |
+| direction  | string | 'none'   | Direction of traffic flow: 'none', 'inbound', or 'outbound'. Defaults to 'none' (no travel direction); generated content follows the segment direction only when set to 'inbound' or 'outbound' |
 | surface    | string | 'asphalt'| Surface material type. One of: 'asphalt', 'concrete', 'grass', 'sidewalk', 'gravel', 'sand', 'cracked-asphalt', 'parking-lot', 'water', 'none', 'solid' |
 | color      | color  | -        | Color of the segment surface |
 | variant    | string | 'custom' | Preset configuration for building segments. One of: 'brownstone', 'suburban', 'arcade', 'water', 'grass', 'parking', 'sp-mixeduse', 'sp-residential', 'sp-big-box', 'custom' |

--- a/docs/managed-street/managed-street-json-format.md
+++ b/docs/managed-street/managed-street-json-format.md
@@ -63,9 +63,11 @@ Each segment represents a distinct part of the street and is defined as follows:
 - `solid`: Solid color surface
 
 ### Direction Options
-- `none`: No direction (for sidewalks, dividers)
-- `inbound`: Traffic flowing inward
-- `outbound`: Traffic flowing outward
+- `none` (default): No travel direction. Generated content is absolutely oriented via its own `facing` value (e.g. side-oriented lamps, benches, bike racks, and sideways/angled parked cars). Used for sidewalks and dividers.
+- `inbound`: Traffic flowing inward. Direction-following content (drive-lane vehicles, parallel-parked cars, lane stencils) orients to this direction.
+- `outbound`: Traffic flowing outward.
+
+When omitted, `direction` resolves to `none`. Only segments whose content should follow traffic flow need to set `inbound` or `outbound`.
 
 ## Generated Content
 


### PR DESCRIPTION
…nvention

Clarify that street-segment 'direction' defaults to 'none' (was previously documented with no default) and that generated content follows traffic flow only when direction is set to 'inbound'/'outbound'; otherwise it is absolutely oriented via 'facing'.